### PR TITLE
Fix building with or without backtrace(3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,7 @@ AC_CHECK_HEADERS(
 		bitstring.h \
 		curses.h \
 		dirent.h \
+		execinfo.h \
 		fcntl.h \
 		inttypes.h \
 		libutil.h \
@@ -121,9 +122,13 @@ AC_CHECK_HEADERS(
 # Look for library needed for flock.
 AC_SEARCH_LIBS(flock, bsd)
 
+# Look for library needed for backtrace
+AC_SEARCH_LIBS(backtrace, execinfo)
+
 # Check for some functions that are replaced or omitted.
 AC_CHECK_FUNCS(
 	[ \
+		backtrace \
 		dirfd \
 		flock \
 		setproctitle \

--- a/tmate-debug.c
+++ b/tmate-debug.c
@@ -1,9 +1,18 @@
+#ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <regex.h>
 #include <signal.h>
 #include "tmate.h"
+
+#ifndef HAVE_BACKTRACE
+
+void tmate_print_stack_trace(void) {}
+void tmate_catch_sigsegv(void) {}
+
+#else
 
 #if DEBUG
 
@@ -88,3 +97,4 @@ void tmate_catch_sigsegv(void)
 {
 	signal(SIGSEGV, handle_sigsegv);
 }
+#endif


### PR DESCRIPTION
backtrace(3) and execinfo.h are GNU extensions and may or may not be
available, and they may be provided via libexecinfo.

Fix detection of libexecinfo and allow building without any support of
backtrace, in which case we let kernel create core dump.

Fixes #116