### PR TITLE
Add support for SHA256 fingerprints and ed25519 keys

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,7 @@ fi
 
 PKG_CHECK_MODULES(
   LIBSSH,
-  libssh >= 0.6.0,
+  libssh >= 0.8.4,
   [
     CPPFLAGS="$LIBSSH_CFLAGS $CPPFLAGS"
     LIBS="$LIBSSH_LIBS $LIBS"
@@ -223,7 +223,7 @@ PKG_CHECK_MODULES(
   found_libssh=no
 )
 if test "x$found_libssh" = xno; then
-  AC_MSG_ERROR("libssh >= 0.6.0 not found")
+  AC_MSG_ERROR("libssh >= 0.8.4 not found")
 fi
 
 # Check for b64_ntop.

--- a/options-table.c
+++ b/options-table.c
@@ -934,6 +934,12 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "SHA256:8GmKHYHEJ6n0TEdciHeEGkKOigQfCFuBULdt6vZIhDc"
 	},
 
+	{ .name = "tmate-server-ed25519-fingerprint",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .default_str = ""
+	},
+
 	{ .name = "tmate-display-time",
 	  .type = OPTIONS_TABLE_NUMBER,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/options-table.c
+++ b/options-table.c
@@ -925,13 +925,13 @@ const struct options_table_entry options_table[] = {
 	{ .name = "tmate-server-rsa-fingerprint",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SERVER,
-	  .default_str = "af:2d:81:c1:fe:49:70:2d:7f:09:a9:d7:4b:32:e3:be"
+	  .default_str = "SHA256:Hthk2T/M/Ivqfk1YYUn5ijC2Att3+UPzD7Rn72P5VWs"
 	},
 
 	{ .name = "tmate-server-ecdsa-fingerprint",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SERVER,
-	  .default_str = "c7:a1:51:36:d2:bb:35:4b:0a:1a:c0:43:97:74:ea:42"
+	  .default_str = "SHA256:8GmKHYHEJ6n0TEdciHeEGkKOigQfCFuBULdt6vZIhDc"
 	},
 
 	{ .name = "tmate-display-time",

--- a/tmate-ssh-client.c
+++ b/tmate-ssh-client.c
@@ -287,12 +287,14 @@ static void on_ssh_client_event(struct tmate_ssh_client *client)
 		if (ssh_get_publickey(session, &pubkey) < 0)
 			tmate_fatal("ssh_get_publickey");
 
-		if (ssh_get_publickey_hash(pubkey, SSH_PUBLICKEY_HASH_MD5, &hash, &hash_len) < 0) {
+		if (ssh_get_publickey_hash(pubkey, SSH_PUBLICKEY_HASH_SHA256,
+					   &hash, &hash_len) < 0) {
 			kill_ssh_client(client, "Cannot authenticate server");
 			return;
 		}
 
-		hash_str = ssh_get_hexa(hash, hash_len);
+		hash_str = ssh_get_fingerprint_hash(SSH_PUBLICKEY_HASH_SHA256,
+						    hash, hash_len);
 		if (!hash_str)
 			tmate_fatal("malloc failed");
 

--- a/tmate-ssh-client.c
+++ b/tmate-ssh-client.c
@@ -309,6 +309,10 @@ static void on_ssh_client_event(struct tmate_ssh_client *client)
 			server_hash_str = options_get_string(global_options,
 						"tmate-server-ecdsa-fingerprint");
 			break;
+		case SSH_KEYTYPE_ED25519:
+			server_hash_str = options_get_string(global_options,
+						"tmate-server-ed25519-fingerprint");
+			break;
 		default:
 			server_hash_str = "";
 		}

--- a/tmate-ssh-client.c
+++ b/tmate-ssh-client.c
@@ -2,6 +2,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <event.h>
 #include <assert.h>
 
@@ -342,6 +343,8 @@ static void on_ssh_client_event(struct tmate_ssh_client *client)
 
 	case SSH_AUTH_CLIENT:
 		client->tried_passphrase = client->tmate_session->passphrase;
+		/* Do not use keys from ssh-agent. */
+		unsetenv("SSH_AUTH_SOCK");
 		switch (ssh_userauth_autopubkey(session, client->tried_passphrase)) {
 		case SSH_AUTH_AGAIN:
 			return;


### PR DESCRIPTION
This adds support for SHA256 fingerprints and ed25519 keys. However the ed25519 key needs to be generated on the tmate.io servers and added.