### PR TITLE
Add build on s390x and ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
     env: PLATFORM=arm32v7
   - arch: arm64
     env: PLATFORM=arm64v8
+  - arch: s390x
+    env: PLATFORM=s390x
+  - arch: ppc64le
+    env: PLATFORM=ppc64le
 
 script:
 - 'docker build . --tag local-$PLATFORM/tmate-build --build-arg PLATFORM=$PLATFORM'


### PR DESCRIPTION
Hi @nviennot,
I propose to add builds on IBM s390x and ppc64le.
We support them on Travis CI.
Passed builds: https://travis-ci.com/travis-ci/tmate/builds/138707276