### PR TITLE
Update paths in build_static_release script

### DIFF
--- a/build_static_release.sh
+++ b/build_static_release.sh
@@ -23,7 +23,7 @@ cd releases
 
 rm -rf $RELEASE_NAME
 mkdir -p $RELEASE_NAME
-docker run --rm local-$PLATFORM/tmate-build cat tmate > $RELEASE_NAME/tmate
+docker run --rm local-$PLATFORM/tmate-build cat /build/tmate > $RELEASE_NAME/tmate
 chmod +x $RELEASE_NAME/tmate
 tar -cf - $RELEASE_NAME | xz > tmate-$VERSION-static-linux-$PLATFORM.tar.xz
 

--- a/build_static_release.sh
+++ b/build_static_release.sh
@@ -29,5 +29,5 @@ tar -cf - $RELEASE_NAME | xz > tmate-$VERSION-static-linux-$PLATFORM.tar.xz
 
 rm -rf $RELEASE_NAME-symbols
 mkdir -p $RELEASE_NAME-symbols
-docker run --rm local-$PLATFORM/tmate-build cat tmate.symbols > $RELEASE_NAME-symbols/tmate.symbols
+docker run --rm local-$PLATFORM/tmate-build cat /build/tmate.symbols > $RELEASE_NAME-symbols/tmate.symbols
 tar -cf - $RELEASE_NAME-symbols | xz > dbg-symbols-tmate-$VERSION-static-linux-$PLATFORM.tar.xz


### PR DESCRIPTION
Hi @nviennot,
After the latest update in Dockerfile got this

> +docker run --rm local-amd64/tmate-build cat tmate
cat: can't open 'tmate': No such file or directory