### PR TITLE
Use tmate-server-port when using libssh 0.9

### DIFF
--- a/tmate-ssh-client.c
+++ b/tmate-ssh-client.c
@@ -269,7 +269,6 @@ static void on_ssh_client_event(struct tmate_ssh_client *client)
 		ssh_set_blocking(session, 0);
 		ssh_options_set(session, SSH_OPTIONS_HOST, client->server_ip);
 		ssh_options_set(session, SSH_OPTIONS_LOG_VERBOSITY, &verbosity);
-		ssh_options_set(session, SSH_OPTIONS_PORT, &port);
 		ssh_options_set(session, SSH_OPTIONS_USER, "tmate");
 		ssh_options_set(session, SSH_OPTIONS_COMPRESSION, "yes");
 
@@ -286,6 +285,14 @@ static void on_ssh_client_event(struct tmate_ssh_client *client)
 			unsetenv("SSH_AUTH_SOCK");
 			free(identity);
 		}
+
+		/*
+		 * libssh 0.9 calls parse_config if it hasn't been parsed
+		 * when doing a ssh_connect overwriting the port.
+		 * So this overwrites port with our tmate-server-port config.
+		 */
+		ssh_options_parse_config(session, NULL);
+		ssh_options_set(session, SSH_OPTIONS_PORT, &port);
 
 		client->state = SSH_CONNECT;
 	}


### PR DESCRIPTION
* Since libssh 0.9 doing ssh_connect will call parse_config
  (unless it is deactivated SSH_OPTIONS_PROCESS_CONFIG)
  if ~/.ssh/config hasn't been parsed, overwriting the port option.
  So this will call parse_first before setting the port with
  tmate-server-port as commit 89a8a6fcf07368c56a98ff8168db77b6814fbe7b.

  Fixes #167

  Commit 89a8a6fcf07368c56a98ff8168db77b6814fbe7b in libssh

 

>  As the configuration parsing is the last thing before doing the
>   actual connection, it might overwrite previously set options.
>   If this is not intended, the client application can
>   ask the configuration files to be parsed before setting some other
>   options that should not ve overwritten.