### PR TITLE
actually enable redefinition of TMUX_CONF

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -53,7 +53,9 @@ struct tmuxpeer;
 struct tmuxproc;
 
 /* Default global configuration file. */
+#ifndef TMUX_CONF
 #define TMUX_CONF "/etc/tmux.conf"
+#endif
 
 /*
  * Minimum layout cell size, NOT including separator line. The scroll region


### PR DESCRIPTION
Without the added #ifndef / #endif it's not possible to _actually_ redefine TMUX_CONF by means of the compiler flag -DTMUX_CONF=... as done by the build system.
The same patch has also been applied to tmux, cf. master at https://github.com/tmux/tmux/blob/master/tmux.h.