### PR TITLE
add basic information for -a option in man page and help text

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -98,6 +98,10 @@ The options are as follows:
 Force
 .Nm
 to assume the terminal supports 256 colours.
+.It Fl a Ar file
+Limit access to the public keys listed in the
+.Ar file
+given as argument.
 .It Fl C
 Start in control mode (see the
 .Sx CONTROL MODE

--- a/tmux.c
+++ b/tmux.c
@@ -68,6 +68,7 @@ usage(void)
 	    " -F           set the foreground mode, useful for setting remote access\n"
 	    " -f <path>    set the config file path\n"
 	    " -S <path>    set the socket path, useful to issue commands to a running tmate instance\n"
+	    " -a <path>    limit access to ssh public keys listed in provided file\n"
 	    " -v           set verbosity (can be repeated)\n"
 	    " -V           print version\n"
 	    ,__progname);


### PR DESCRIPTION
There is some lacks in man page and help message. All options are not listed. I only focused here on -a as it is of importance to me to communicate on the ability of tmate to control access