### PR TITLE
Fix finding msgpack 6+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,17 @@ PKG_CHECK_MODULES(
   ],
   found_msgpack=no
 )
+# msgpack.pc was renamed to msgpack-c.pc in 6.0.0.
+PKG_CHECK_MODULES(
+  MSGPACKC,
+  msgpack-c >= 1.1.0,
+  [
+    CPPFLAGS="$MSGPACKC_CFLAGS $CPPFLAGS"
+    LIBS="$MSGPACKC_LIBS $LIBS"
+    found_msgpack=yes
+  ],
+  found_msgpack=no
+)
 if test "x$found_msgpack" = xno; then
   AC_MSG_ERROR("msgpack >= 1.1.0 not found")
 fi


### PR DESCRIPTION
`msgpack.pc` was renamed to `msgpack-c.pc` upstream in msgpack/msgpack-c#1053.