### PR TITLE
compat/fparseln.c: Update license notice

### DIFF
--- a/compat/fparseln.c
+++ b/compat/fparseln.c
@@ -12,11 +12,6 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by Christos Zoulas.
- * 4. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES


### PR DESCRIPTION
This was the only file under the somewhat problematic 4-clause BSD license, but Christos Zoulas agreed to rescind clause 3 and 4.

https://mail-index.netbsd.org/source-changes/2009/10/21/msg002182.html https://cvsweb.openbsd.org/src/lib/libutil/fparseln.c