### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/format.c
+++ b/format.c
@@ -468,6 +468,8 @@ format_cb_pane_tabs(struct format_tree *ft, struct format_entry *fe)
 		return;
 
 	buffer = evbuffer_new();
+	if (buffer == NULL)
+		fatalx("out of memory");
 	for (i = 0; i < wp->base.grid->sx; i++) {
 		if (!bit_test(wp->base.tabs, i))
 			continue;

--- a/input.c
+++ b/input.c
@@ -766,6 +766,8 @@ input_init(struct window_pane *wp)
 	ictx->input_buf = xmalloc(INPUT_BUF_START);
 
 	ictx->since_ground = evbuffer_new();
+	if (ictx->since_ground == NULL)
+		fatalx("out of memory");
 
 	input_reset(wp, 0);
 }

--- a/server-client.c
+++ b/server-client.c
@@ -121,8 +121,14 @@ server_client_create(int fd)
 	c->cmdq->client_exit = 1;
 
 	c->stdin_data = evbuffer_new();
+	if (c->stdin_data == NULL)
+		fatalx("out of memory");
 	c->stdout_data = evbuffer_new();
+	if (c->stdout_data == NULL)
+		fatalx("out of memory");
 	c->stderr_data = evbuffer_new();
+	if (c->stderr_data == NULL)
+		fatalx("out of memory");
 
 	c->tty.fd = -1;
 	c->title = NULL;

--- a/window.c
+++ b/window.c
@@ -945,6 +945,8 @@ window_pane_spawn(struct window_pane *wp, int argc, char **argv,
 
 	wp->event = bufferevent_new(wp->fd, window_pane_read_callback, NULL,
 	    window_pane_error_callback, wp);
+	if (wp->event == NULL)
+		fatalx("out of memory");
 
 	bufferevent_setwatermark(wp->event, EV_READ, 0, READ_SIZE);
 	bufferevent_enable(wp->event, EV_READ|EV_WRITE);


### PR DESCRIPTION
Hi Tmate Development Team,

Our tool identified a potential vulnerability in clone functions in `format.c`, `input.c`, `server-client.c`, and `window.c` sourced from [openbsd/src](https://github.com/openbsd/src). These issues, originally reported in [CVE-2018-19387](https://access.redhat.com/security/cve/cve-2018-19387), were resolved in the repository via this commit https://github.com/openbsd/src/commit/b32e1d34e10a0da806823f57f02a4ae6e93d756e.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.