### PR TITLE
Fix crash when an unknown tparam is used

### DIFF
--- a/tty-term.c
+++ b/tty-term.c
@@ -570,26 +570,42 @@ tty_term_string(struct tty_term *term, enum tty_code_code code)
 const char *
 tty_term_string1(struct tty_term *term, enum tty_code_code code, int a)
 {
-	return (tparm((char *) tty_term_string(term, code), a, 0, 0, 0, 0, 0, 0, 0, 0));
+	const char *x = tty_term_string(term, code);
+	const char *s = tparm((char *)x, a, 0, 0, 0, 0, 0, 0, 0, 0);
+	if (s == NULL)
+		return ("");
+	return (s);
 }
 
 const char *
 tty_term_string2(struct tty_term *term, enum tty_code_code code, int a, int b)
 {
-	return (tparm((char *) tty_term_string(term, code), a, b, 0, 0, 0, 0, 0, 0, 0));
+	const char *x = tty_term_string(term, code);
+	const char *s = tparm((char *)x, a, b, 0, 0, 0, 0, 0, 0, 0);
+	if (s == NULL)
+		return ("");
+	return (s);
 }
 
 const char *
 tty_term_ptr1(struct tty_term *term, enum tty_code_code code, const void *a)
 {
-	return (tparm((char *) tty_term_string(term, code), a, 0, 0, 0, 0, 0, 0, 0, 0));
+	const char *x = tty_term_string(term, code);
+	const char *s = tparm((char *)x, a, 0, 0, 0, 0, 0, 0, 0, 0);
+	if (s == NULL)
+		return ("");
+	return (s);
 }
 
 const char *
 tty_term_ptr2(struct tty_term *term, enum tty_code_code code, const void *a,
     const void *b)
 {
-	return (tparm((char *) tty_term_string(term, code), a, b, 0, 0, 0, 0, 0, 0, 0));
+	const char *x = tty_term_string(term, code);
+	const char *s = tparm((char *)x, a, b, 0, 0, 0, 0, 0, 0, 0);
+	if (s == NULL)
+		return ("");
+	return (s);
 }
 
 int


### PR DESCRIPTION
This can be reproduced by setting the cursor colour using an escape code.
I first bumped into this when attempting to run Opencode's coding assistant.

Reproduce using:

    tmate -c "printf '\033]12;#eeeabc\033\\'"

This commit is based on the following, from the tmux codebase:

    commit bf636d9575806134ca7efd917ee0d54e9330ae86
    Author: Nicholas Marriott <nicholas.marriott@gmail.com>
    Date:   Fri Apr 28 05:59:35 2023 +0000

        Do not fatal if tparm fails, instead just log it (not working sequences
        are better than exiting).