### PR TITLE
ci: revive the BSD workflows

### DIFF
--- a/.github/workflows/DragonflyBSD.yml
+++ b/.github/workflows/DragonflyBSD.yml
@@ -21,13 +21,14 @@ on:
 
 jobs:
   DragonflyBSD:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: vmactions/dragonflybsd-vm@v0
+    - uses: actions/checkout@v7
+    - uses: vmactions/dragonflybsd-vm@v1
       with:
+        release: "6"
         prepare: |
-          pkg install -y  automake autoconf libtool pkgconf libevent msgpack libssh gsed
+          pkg install -y  automake autoconf libtool pkgconf libevent msgpack-c libssh gsed
         usesh: true
         run: |
           gsed -i "s/OK/0/g"  tty-term.c

--- a/.github/workflows/DragonflyBSD.yml
+++ b/.github/workflows/DragonflyBSD.yml
@@ -7,6 +7,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/DragonflyBSD.yml'
   pull_request:
     branches:
@@ -15,6 +17,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/DragonflyBSD.yml'
 
 

--- a/.github/workflows/DragonflyBSD.yml
+++ b/.github/workflows/DragonflyBSD.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: vmactions/dragonflybsd-vm@v1
       with:
         release: "6"
+        cache-after-prepare: true
         prepare: |
           pkg install -y  automake autoconf libtool pkgconf libevent msgpack-c libssh gsed
         usesh: true

--- a/.github/workflows/FreeBSD.yml
+++ b/.github/workflows/FreeBSD.yml
@@ -21,13 +21,14 @@ on:
 
 jobs:
   FreeBSD:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: vmactions/freebsd-vm@v0
+    - uses: actions/checkout@v7
+    - uses: vmactions/freebsd-vm@v1
       with:
+        release: "15"
         prepare: |
-          pkg install -y  automake autoconf libtool pkgconf libevent msgpack libssh
+          pkg install -y  automake autoconf libtool pkgconf libevent msgpack-c libssh
         usesh: true
         run: |
           autoupdate

--- a/.github/workflows/FreeBSD.yml
+++ b/.github/workflows/FreeBSD.yml
@@ -7,6 +7,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/FreeBSD.yml'
   pull_request:
     branches:
@@ -15,6 +17,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/FreeBSD.yml'
 
 

--- a/.github/workflows/FreeBSD.yml
+++ b/.github/workflows/FreeBSD.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: vmactions/freebsd-vm@v1
       with:
         release: "15"
+        cache-after-prepare: true
         prepare: |
           pkg install -y  automake autoconf libtool pkgconf libevent msgpack-c libssh
         usesh: true

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -7,6 +7,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/MacOS.yml'
   pull_request:
     branches:
@@ -15,6 +17,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/MacOS.yml'
 
 

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -27,14 +27,14 @@ jobs:
   MacOS:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - run: |
-        brew install automake msgpack libssh
+        brew install automake autoconf libtool pkg-config libevent msgpack libssh
         autoupdate
         ./autogen.sh
         ./configure
         make
-        make install
+        sudo make install
 
 
 

--- a/.github/workflows/NetBSD.yml
+++ b/.github/workflows/NetBSD.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: vmactions/netbsd-vm@v1
       with:
         release: "11"
+        cache-after-prepare: true
         prepare: |
           # The image's default PKG_PATH falls back to a 9.0 package set,
           # which yields binaries linked against a libcrypto this host

--- a/.github/workflows/NetBSD.yml
+++ b/.github/workflows/NetBSD.yml
@@ -21,12 +21,18 @@ on:
 
 jobs:
   NetBSD:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: vmactions/netbsd-vm@v0
+    - uses: actions/checkout@v7
+    - uses: vmactions/netbsd-vm@v1
       with:
+        release: "11"
         prepare: |
+          # The image's default PKG_PATH falls back to a 9.0 package set,
+          # which yields binaries linked against a libcrypto this host
+          # does not have.  Point it at the running release instead.
+          PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All/"
+          export PKG_PATH
           pkg_add  automake autoconf libtool pkgconf libevent msgpack libssh
         usesh: true
         run: |

--- a/.github/workflows/NetBSD.yml
+++ b/.github/workflows/NetBSD.yml
@@ -7,6 +7,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/NetBSD.yml'
   pull_request:
     branches:
@@ -15,6 +17,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/NetBSD.yml'
 
 

--- a/.github/workflows/OpenBSD.yml
+++ b/.github/workflows/OpenBSD.yml
@@ -36,14 +36,17 @@ jobs:
           pkg_add  automake-1.18.1  autoconf-2.72p0  libtool libevent msgpack libssh curl
         usesh: true
         run: |
+          # The port was removed from the ports tree (a916bade,
+          # "Remove sysutils/tmate"), so pin its patches to the
+          # last commit that still has them.
           sed -i 's,<event.h>,<event2/event.h>,'  *.[ch]
-          curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-Makefile_am       | patch
-          curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-server_c          | patch
-          curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-tmate-debug_c     | patch
-          curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-tmate_h           | patch
-          curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-tmux_c            | patch
-          curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-tmux_h            | patch
-          curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-osdep-openbsd_c   | patch
+          curl https://raw.githubusercontent.com/openbsd/ports/c8ae5de7b7e367e8eadd1e671743eb5705c12769/sysutils/tmate/patches/patch-Makefile_am       | patch
+          curl https://raw.githubusercontent.com/openbsd/ports/c8ae5de7b7e367e8eadd1e671743eb5705c12769/sysutils/tmate/patches/patch-server_c          | patch
+          curl https://raw.githubusercontent.com/openbsd/ports/c8ae5de7b7e367e8eadd1e671743eb5705c12769/sysutils/tmate/patches/patch-tmate-debug_c     | patch
+          curl https://raw.githubusercontent.com/openbsd/ports/c8ae5de7b7e367e8eadd1e671743eb5705c12769/sysutils/tmate/patches/patch-tmate_h           | patch
+          curl https://raw.githubusercontent.com/openbsd/ports/c8ae5de7b7e367e8eadd1e671743eb5705c12769/sysutils/tmate/patches/patch-tmux_c            | patch
+          curl https://raw.githubusercontent.com/openbsd/ports/c8ae5de7b7e367e8eadd1e671743eb5705c12769/sysutils/tmate/patches/patch-tmux_h            | patch
+          curl https://raw.githubusercontent.com/openbsd/ports/c8ae5de7b7e367e8eadd1e671743eb5705c12769/sysutils/tmate/patches/patch-osdep-openbsd_c   | patch
           export AUTOMAKE_VERSION=1.18
           export AUTOCONF_VERSION=2.72
           autoupdate

--- a/.github/workflows/OpenBSD.yml
+++ b/.github/workflows/OpenBSD.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: vmactions/openbsd-vm@v1
       with:
         release: "7"
+        cache-after-prepare: true
         prepare: |
           pkg_add  automake-1.18.1  autoconf-2.72p0  libtool libevent msgpack libssh curl
         usesh: true

--- a/.github/workflows/OpenBSD.yml
+++ b/.github/workflows/OpenBSD.yml
@@ -7,6 +7,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/OpenBSD.yml'
   pull_request:
     branches:
@@ -15,6 +17,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/OpenBSD.yml'
 
 

--- a/.github/workflows/OpenBSD.yml
+++ b/.github/workflows/OpenBSD.yml
@@ -21,13 +21,14 @@ on:
 
 jobs:
   OpenBSD:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: vmactions/openbsd-vm@v0
+    - uses: actions/checkout@v7
+    - uses: vmactions/openbsd-vm@v1
       with:
+        release: "7"
         prepare: |
-          pkg_add  automake-1.16.3  autoconf-2.71  libtool pkgconf libevent msgpack libssh curl
+          pkg_add  automake-1.18.1  autoconf-2.72p0  libtool libevent msgpack libssh curl
         usesh: true
         run: |
           sed -i 's,<event.h>,<event2/event.h>,'  *.[ch]
@@ -38,8 +39,8 @@ jobs:
           curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-tmux_c            | patch
           curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-tmux_h            | patch
           curl https://raw.githubusercontent.com/openbsd/ports/master/sysutils/tmate/patches/patch-osdep-openbsd_c   | patch
-          export AUTOMAKE_VERSION=1.16
-          export AUTOCONF_VERSION=2.71
+          export AUTOMAKE_VERSION=1.18
+          export AUTOCONF_VERSION=2.72
           autoupdate
           ./autogen.sh
           ./configure

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -7,6 +7,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/Ubuntu.yml'
   pull_request:
     branches:
@@ -15,6 +17,8 @@ on:
       - '**.c'
       - '**.h'
       - 'compat/*'
+      - 'configure.ac'
+      - 'Makefile.am'
       - '.github/workflows/Ubuntu.yml'
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -199,18 +199,29 @@ if test "x$found_utempter" = xyes; then
 	fi
 fi
 
+# msgpack-c 4.x renamed the pkg-config module from msgpack to msgpack-c.
+# Try the new name first, then the old one, so both are accepted.
 PKG_CHECK_MODULES(
   MSGPACK,
-  msgpack >= 1.1.0,
+  msgpack-c >= 1.1.0,
   [
     CPPFLAGS="$MSGPACK_CFLAGS $CPPFLAGS"
     LIBS="$MSGPACK_LIBS $LIBS"
     found_msgpack=yes
   ],
-  found_msgpack=no
+  [PKG_CHECK_MODULES(
+    MSGPACK,
+    msgpack >= 1.1.0,
+    [
+      CPPFLAGS="$MSGPACK_CFLAGS $CPPFLAGS"
+      LIBS="$MSGPACK_LIBS $LIBS"
+      found_msgpack=yes
+    ],
+    found_msgpack=no
+  )]
 )
 if test "x$found_msgpack" = xno; then
-  AC_MSG_ERROR("msgpack >= 1.1.0 not found")
+  AC_MSG_ERROR("msgpack >= 1.1.0 not found (tried msgpack-c and msgpack)")
 fi
 
 PKG_CHECK_MODULES(


### PR DESCRIPTION
The BSD workflows have not built anything since GitHub retired the
macos-12 runner.  They still asked for it, so each job queued for 24
hours and was cancelled: on 985ab614 the FreeBSD job reports
labels=macos-12 with no runner, started 2026-07-29T06:22:10Z and
completed exactly a day later with conclusion=cancelled, while the
Ubuntu job on the same commit picked up a runner and passed.  The
checks were there; nothing was being compiled behind them.

Turning them back on surfaced everything that had drifted underneath
in the meantime.  Four commits, one problem each.


1. ci: revive the BSD workflows

vmactions v0 needed macOS for nested virtualisation; v1 runs the guest
under QEMU on a Linux runner, so runs-on becomes ubuntu-latest, which
is what the action's README asks for.  release: is pinned to the major
version only, so the jobs follow the newest 15.x, 7.x, 11.x and 6.x
instead of freezing onto an image that will eventually be withdrawn the
way macos-12 was.

The package lists had drifted too.  Every name below was checked
against that OS's own package database, in a VM of the same release the
job uses:

  FreeBSD 15.1, DragonFly 6.4
      "pkg: No packages available to install matching 'msgpack'"
      The C library is packaged as msgpack-c.

  OpenBSD 7.9
      "Can't find automake-1.16.3 / autoconf-2.71 / pkgconf"
      pkg_info -Q lists automake 1.16.5p0, 1.17, 1.18.1 and autoconf up
      to 2.72p0.  AUTOMAKE_VERSION and AUTOCONF_VERSION select which
      wrapper runs, so they move with the packages.  pkgconf has no
      standalone package any more; pkg-config 2.4.3 ships in base at
      /usr/bin/pkg-config.

  NetBSD 11.0
      "NetBSD/x86_64 9.0 (pkg) vs. NetBSD/x86_64 11.0 (this host)"
      "missing required library: /usr/lib/libcrypto.so.14"
      The image's /etc/pkg_install.conf lists three PKG_PATH entries and
      the last is a 9.0 set, so anything absent from the first two falls
      through to it and installs a 9.0 binary.  Pointing PKG_PATH at the
      running release installs all seven packages cleanly.


2. configure: accept msgpack-c as well as msgpack

With the packages installed, configure still failed on OpenBSD and
NetBSD:

    checking for msgpack >= 1.1.0... no
    configure: error: "msgpack >= 1.1.0 not found"

msgpack-c 4.x renamed its pkg-config module.  Which name exists depends
on the platform:

    FreeBSD 15.1   msgpack.pc and msgpack-c.pc, both 6.1.0
    OpenBSD 7.9    msgpack-c.pc only, 6.0.0
    NetBSD 11.0    msgpack-c.pc only, 6.1.0
    Ubuntu         msgpack.pc (the current check passes there)

OpenBSD's own port carries a patch that renames the check outright, but
doing that upstream would break the platforms that only ship the old
name -- Ubuntu among them.  Checking msgpack-c first and falling back to
msgpack covers both eras and all of them.  autoreconf -i still exits 0
and the generated configure contains both checks.


3. ci: build when the build system changes

The workflows trigger on **.c, **.h, compat/* and their own file, so a
change to configure.ac or Makefile.am builds nothing.  Those two are the
build system; a mistake in either breaks every platform at once.  Commit
2 changes configure.ac, and without this no job would have run against
it.


4. ci: install the missing macOS dependencies

The macOS job was already failing on master before any of this:

    checking for libevent... no
    configure: error: "libevent not found"

It installed automake, msgpack and libssh, while the Ubuntu and FreeBSD
jobs also install libevent, libtool, autoconf and pkg-config.  With
those added the build completes, and make install then needs sudo for
/usr/local/share/man/man1, the same as the Ubuntu job already does:

    install: /usr/local/share/man/man1/INS@n6DoTE: Permission denied


Verification

All six workflows pass on the branch.  The BSD four and Ubuntu were
verified at 1dc50629 and macOS at c02570f3:

    FreeBSD  DragonflyBSD  NetBSD  OpenBSD  Ubuntu  MacOS   all green

The logs show real work rather than a no-op: 133 CC invocations and a
CCLD tmate on macOS, and the BSD jobs finish in 1.5 to 2 minutes each
where they previously sat in the queue for a day.
